### PR TITLE
Investigate mac crashing after api agent interaction

### DIFF
--- a/LaunchCursor.command
+++ b/LaunchCursor.command
@@ -1,0 +1,2 @@
+#!/bin/bash
+open -a '/Applications/Cursor.app/Contents/MacOS/Cursor' --args --disable-gpu-compositing --js-flags="--max-old-space-size=4096"


### PR DESCRIPTION
Create a script to launch Cursor with flags to prevent Mac crashes caused by the background API agent beta feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc14956b-69fc-41d2-84d6-766e8e52664e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc14956b-69fc-41d2-84d6-766e8e52664e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

